### PR TITLE
Expose string-content

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -118,7 +118,7 @@ module.exports = grammar({
     $.multiline_comment,
     $._string_start,
     $._string_end,
-    $._string_content,
+    $.string_content,
   ],
 
   extras: $ => [
@@ -762,7 +762,7 @@ module.exports = grammar({
 
     string_literal: $ => seq(
       $._string_start,
-      repeat(choice($._string_content, $._interpolation)),
+      repeat(choice($.string_content, $._interpolation)),
       $._string_end,
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6341,4 +6341,3 @@
   "inline": [],
   "supertypes": []
 }
-

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3818,7 +3818,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_string_content"
+                "name": "string_content"
               },
               {
                 "type": "SYMBOL",
@@ -6335,9 +6335,10 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_string_content"
+      "name": "string_content"
     }
   ],
   "inline": [],
   "supertypes": []
 }
+

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -7824,6 +7824,10 @@
         {
           "type": "interpolated_identifier",
           "named": true
+        },
+        {
+          "type": "string_content",
+          "named": true
         }
       ]
     }
@@ -9523,6 +9527,10 @@
   {
     "type": "setparam",
     "named": false
+  },
+  {
+    "type": "string_content",
+    "named": true
   },
   {
     "type": "super",

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -66,9 +66,12 @@ extern "C" {
 /// Increase the array's size by `count` elements.
 /// New elements are zero-initialized.
 #define array_grow_by(self, count) \
-  (_array__grow((Array *)(self), count, array_elem_size(self)), \
-   memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)), \
-   (self)->size += (count))
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
 
 /// Append all elements from one array to the end of another.
 #define array_push_all(self, other)                                       \

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,9 +13,8 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-typedef uint16_t TSStateId;
-
 #ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -87,6 +86,11 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -126,13 +130,38 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
 /*
  *  Lexer Macros
  */
 
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
+  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -146,6 +175,17 @@ struct TSLanguage {
   {                          \
     state = state_value;     \
     goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -166,7 +206,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
 
 #define STATE(id) id
 
@@ -176,7 +216,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value            \
+      .state = (state_value)          \
     }                                 \
   }}
 
@@ -184,7 +224,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value,           \
+      .state = (state_value),         \
       .repetition = true              \
     }                                 \
   }}
@@ -197,14 +237,15 @@ struct TSLanguage {
     }                                 \
   }}
 
-#define REDUCE(symbol_val, child_count_val, ...) \
-  {{                                             \
-    .reduce = {                                  \
-      .type = TSParseActionTypeReduce,           \
-      .symbol = symbol_val,                      \
-      .child_count = child_count_val,            \
-      __VA_ARGS__                                \
-    },                                           \
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
   }}
 
 #define RECOVER()                    \

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,8 +13,9 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -129,16 +130,9 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
-#ifdef _MSC_VER
-#define UNUSED __pragma(warning(suppress : 4101))
-#else
-#define UNUSED __attribute__((unused))
-#endif
-
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
-  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -172,7 +166,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
 
 #define STATE(id) id
 
@@ -182,7 +176,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value)          \
+      .state = state_value            \
     }                                 \
   }}
 
@@ -190,7 +184,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = (state_value),         \
+      .state = state_value,           \
       .repetition = true              \
     }                                 \
   }}

--- a/test/corpus/assignment.txt
+++ b/test/corpus/assignment.txt
@@ -64,4 +64,4 @@ fun main(){
             (simple_identifier)
             (indexing_suffix
               (integer_literal)))
-          (string_literal))))))
+          (string_literal (string_content)))))))

--- a/test/corpus/classes.txt
+++ b/test/corpus/classes.txt
@@ -75,16 +75,16 @@ class Strings {
        (simple_identifier)
        (function_value_parameters)
        (function_body
-        (string_literal)))
+        (string_literal (string_content))))
       (function_declaration
        (simple_identifier)
        (function_value_parameters)
        (function_body
         (additive_expression
           (additive_expression
-              (string_literal)
-              (string_literal))
-            (string_literal)))))))
+              (string_literal (string_content))
+              (string_literal (string_content)))
+            (string_literal (string_content))))))))
 
 ================================================================================
 Class with modifiers

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -76,7 +76,7 @@ sum(1, 2)
     (call_suffix
       (value_arguments
         (value_argument
-          (string_literal)))))
+          (string_literal (string_content))))))
   (call_expression
     (simple_identifier)
     (call_suffix
@@ -162,7 +162,7 @@ val MyDate.s: String get() = "hello"
         (type_identifier)))
     (getter
       (function_body
-        (string_literal)))))
+        (string_literal (string_content))))))
 
 ================================================================================
 Expect as an expression
@@ -429,7 +429,7 @@ val comments = """ // and here """
       (call_suffix
         (value_arguments
           (value_argument
-            (string_literal))))))
+            (string_literal (string_content)))))))
   (property_declaration
     (variable_declaration
       (simple_identifier))
@@ -438,7 +438,7 @@ val comments = """ // and here """
       (call_suffix
         (value_arguments
           (value_argument
-            (string_literal))))))
+            (string_literal (string_content)))))))
   (property_declaration
     (variable_declaration
       (simple_identifier))
@@ -447,7 +447,7 @@ val comments = """ // and here """
       (call_suffix
         (value_arguments
           (value_argument
-            (string_literal))))))
+            (string_literal (string_content)))))))
   (property_declaration
     (variable_declaration
       (simple_identifier))
@@ -456,15 +456,15 @@ val comments = """ // and here """
       (call_suffix
         (value_arguments
           (value_argument
-            (string_literal))))))
+            (string_literal (string_content)))))))
   (property_declaration
     (variable_declaration
       (simple_identifier))
-    (string_literal))
+    (string_literal (string_content)))
   (property_declaration
     (variable_declaration
       (simple_identifier))
-    (string_literal)))
+    (string_literal (string_content))))
 
 ================================================================================
 Qualified this/super expressions

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -46,8 +46,12 @@ string.
 --------------------------------------------------------------------------------
 
 (source_file
-  (string_literal)
-  (string_literal))
+  (string_literal
+    (string_content))
+  (string_literal
+    (string_content)
+    (string_content)
+    (string_content)))
 
 ================================================================================
 String literal with lots of repeated quotes
@@ -59,7 +63,15 @@ There's a lot of ""quotations"". Even at the "end""""
 --------------------------------------------------------------------------------
 
 (source_file
-  (string_literal))
+  (string_literal
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content)))
 
 ================================================================================
 String interpolation
@@ -76,14 +88,23 @@ ${"""string interpolation"""} $literal
 
 (source_file
   (string_literal
-    (interpolated_identifier))
+    (string_content)
+    (interpolated_identifier)
+    (string_content))
   (string_literal
+    (string_content)
     (interpolated_expression
-      (string_literal)))
+      (string_literal
+        (string_content)))
+    (string_content))
   (string_literal
+    (string_content)
     (interpolated_expression
-      (string_literal))
-    (interpolated_identifier)))
+      (string_literal
+        (string_content)))
+    (string_content)
+    (interpolated_identifier)
+    (string_content)))
 
 ================================================================================
 More string interpolation
@@ -97,10 +118,19 @@ More string interpolation
 --------------------------------------------------------------------------------
 
 (source_file
-  (string_literal)
-  (string_literal)
-  (string_literal)
-  (string_literal))
+  (string_literal
+    (string_content))
+  (string_literal
+    (string_content)
+    (string_content))
+  (string_literal
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content)
+    (string_content))
+  (string_literal
+    (string_content)))
 
 ================================================================================
 Integer literals
@@ -154,11 +184,11 @@ assertEquals("\u214E\uA7B5\u2CEF", "\u2132\uA7B4\u2CEF".lowercase())
     (call_suffix
       (value_arguments
         (value_argument
-          (string_literal))
+          (string_literal (string_content)))
         (value_argument
           (call_expression
             (navigation_expression
-              (string_literal)
+              (string_literal (string_content))
               (navigation_suffix
                 (simple_identifier)))
             (call_suffix

--- a/test/corpus/newlines.txt
+++ b/test/corpus/newlines.txt
@@ -78,7 +78,7 @@ fun foo():String
     (function_body
       (statements
         (jump_expression
-          (string_literal))))))
+          (string_literal (string_content)))))))
 
 ================================================================================
 Colon after newline

--- a/test/corpus/source-files.txt
+++ b/test/corpus/source-files.txt
@@ -15,7 +15,7 @@ val x = 4
         (type_identifier))
       (value_arguments
         (value_argument
-          (string_literal)))))
+          (string_literal (string_content))))))
   (property_declaration
     (variable_declaration
       (simple_identifier))
@@ -41,7 +41,7 @@ Multiple file annotations
         (type_identifier))
       (value_arguments
         (value_argument
-          (string_literal)))))
+          (string_literal (string_content))))))
   (file_annotation
     (constructor_invocation
       (user_type

--- a/test/corpus/types.txt
+++ b/test/corpus/types.txt
@@ -228,10 +228,10 @@ a as Foo(x = "hi", y = "bar")
       (value_arguments
         (value_argument
           (simple_identifier)
-          (string_literal))
+          (string_literal (string_content)))
         (value_argument
           (simple_identifier)
-          (string_literal))))))
+          (string_literal (string_content)))))))
 
 ================================================================================
 Type constructor with trailing comma
@@ -251,10 +251,10 @@ a as Foo(x = "hi", y = "bar",)
       (value_arguments
         (value_argument
           (simple_identifier)
-          (string_literal))
+          (string_literal (string_content)))
         (value_argument
           (simple_identifier)
-          (string_literal))))))
+          (string_literal (string_content)))))))
 
 ================================================================================
 Type alias with type parameters


### PR DESCRIPTION
Expose string_content to the parse tree so that we don't need to manually strip quotes to get the string content.