### PR TITLE
Add star-import nonterminal to retain '.*' in the parse tree

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -168,11 +168,13 @@ module.exports = grammar({
     import_header: $ => seq(
       "import",
       $.identifier,
-      optional(choice(seq(".*"), $.import_alias)),
+      optional(choice($.star_import, $.import_alias)),
       $._semi
     ),
 
-    import_alias: $ => seq("as", alias($.simple_identifier, $.type_identifier)),
+    star_import: $ => seq(".*"),
+
+    import_alias: $ => seq("as", $.simple_identifier),
 
     top_level_object: $ => seq($._declaration, optional($._semi)),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -175,13 +175,8 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ".*"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "star_import"
                 },
                 {
                   "type": "SYMBOL",
@@ -200,6 +195,15 @@
         }
       ]
     },
+    "star_import": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ".*"
+        }
+      ]
+    },
     "import_alias": {
       "type": "SEQ",
       "members": [
@@ -208,13 +212,8 @@
           "value": "as"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "simple_identifier"
-          },
-          "named": true,
-          "value": "type_identifier"
+          "type": "SYMBOL",
+          "name": "simple_identifier"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4209,7 +4209,7 @@
       "required": true,
       "types": [
         {
-          "type": "type_identifier",
+          "type": "simple_identifier",
           "named": true
         }
       ]
@@ -4229,6 +4229,10 @@
         },
         {
           "type": "import_alias",
+          "named": true
+        },
+        {
+          "type": "star_import",
           "named": true
         }
       ]
@@ -7589,6 +7593,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "star_import",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "statements",

--- a/test/corpus/imports.txt
+++ b/test/corpus/imports.txt
@@ -1,0 +1,64 @@
+==================
+simple import
+==================
+
+import pkg
+
+---
+
+(source_file
+  (import_list
+    (import_header
+      (identifier
+        (simple_identifier)))))
+
+==================
+qualified import
+==================
+
+import a.b.c
+
+---
+
+(source_file
+  (import_list
+    (import_header
+      (identifier
+        (simple_identifier)
+        (simple_identifier)
+        (simple_identifier)))))
+
+==================
+import alias
+==================
+
+import a.b.c as x
+
+---
+
+(source_file
+  (import_list
+    (import_header
+      (identifier
+        (simple_identifier)
+        (simple_identifier)
+        (simple_identifier))
+      (import_alias
+        (simple_identifier)))))
+
+==================
+star import
+==================
+
+import a.b.c.*
+
+---
+
+(source_file
+  (import_list
+    (import_header
+      (identifier
+        (simple_identifier)
+        (simple_identifier)
+        (simple_identifier))
+      (star_import))))


### PR DESCRIPTION
Currently, it is not possible to distinguish star imports in the parse tree because .* is not retained. This PR exposes the star_import nonterminal to retain this information in the parse tree.