### PR TITLE
Fix disjunction and prefix expression precedence

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -657,7 +657,9 @@ module.exports = grammar({
       ']')
     ),
 
-    prefix_expression: $ => seq(choice($.annotation, $.label, field('op', $.prefix_unary_operator)), field('expression', $.expression)),
+    prefix_expression: $ => choice(
+      seq(choice($.annotation, $.label), field('expression', $.expression)),
+      prec(PREC.PREFIX, seq(field('op', $.prefix_unary_operator), field('expression', $.expression)))),
 
     as_expression: $ => prec(PREC.AS, seq($.expression, $._as_operator, $._type)),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3192,35 +3192,57 @@
       }
     },
     "prefix_expression": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "annotation"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "label"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "annotation"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "label"
+                }
+              ]
             },
             {
               "type": "FIELD",
-              "name": "op",
+              "name": "expression",
               "content": {
                 "type": "SYMBOL",
-                "name": "prefix_unary_operator"
+                "name": "expression"
               }
             }
           ]
         },
         {
-          "type": "FIELD",
-          "name": "expression",
+          "type": "PREC",
+          "value": 15,
           "content": {
-            "type": "SYMBOL",
-            "name": "expression"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "op",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "prefix_unary_operator"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "expression",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              }
+            ]
           }
         }
       ]

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -954,3 +954,28 @@ it.sliceArray(1..<it.size)
           (dot_qualified_expression
             receiver: (simple_identifier)
             selector: (simple_identifier)))))))
+
+================================================================================
+Disjunction and negation expression
+================================================================================
+
+!x||y
+!x&&!y||y
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (disjunction_expression
+    left: (prefix_expression
+      op: (prefix_unary_operator)
+      expression: (simple_identifier))
+    right: (simple_identifier))
+  (disjunction_expression
+    left: (conjunction_expression
+      left: (prefix_expression
+        op: (prefix_unary_operator)
+        expression: (simple_identifier))
+      right: (prefix_expression
+        op: (prefix_unary_operator)
+        expression: (simple_identifier)))
+    right: (simple_identifier)))


### PR DESCRIPTION
Fix disjunction and prefix expression precedence: `!x||y` should be parsed as `(!x)||y`, and not as `!(x||y)`. This is a high priority fix for boolean simplification.